### PR TITLE
DIP the Logger

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -3,18 +3,34 @@
 namespace NodePile\PHPTelemetry;
 
 use NodePile\PHPTelemetry\Exceptions\InvalidLevelException;
+use NodePile\PHPTelemetry\Contracts\DriverManagerInterface;
 use NodePile\PHPTelemetry\Contracts\LoggerInterface;
+use NodePile\PHPTelemetry\Contracts\TimeProviderInterface;
 use NodePile\PHPTelemetry\Enums\Level;
+use NodePile\PHPTelemetry\Models\Entry;
 
 class Logger implements LoggerInterface
-{
+{	
+	/**
+	 * @var DriverManagerInterface
+	 */
+	private DriverManagerInterface $driverManager;
+
+	/**
+	 * @var TimeProviderInterface
+	 */
+	private TimeProviderInterface $timeProvider;
+
 	/**
 	 * @var array
 	 */
 	private array $supportedLevels = [];
 
-	public function __construct()
+	public function __construct(DriverManagerInterface $driverManager, TimeProviderInterface $timeProvider)
 	{
+		$this->driverManager = $driverManager;
+		$this->timeProvider = $timeProvider;
+
 		$this->supportedLevels = $this->loadDefaultLevels();
 	}
 
@@ -76,7 +92,9 @@ class Logger implements LoggerInterface
 			throw new InvalidLevelException("Level '{$level}' is not supported.");
 		}
 
-		// write the log
+		$entry = new Entry($this->timeProvider->now(), $level, $message, $context);
+
+		$this->driverManager->getCurrDriver()->write($entry);
 	}
 
 	/**

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -5,18 +5,25 @@ namespace NodePile\PHPTelemetry\Tests;
 use PHPUnit\Framework\TestCase;
 
 use NodePile\PHPTelemetry\Exceptions\InvalidLevelException;
+use NodePile\PHPTelemetry\Contracts\LoggerInterface;
+use NodePile\PHPTelemetry\Contracts\DriverManagerInterface;
+use NodePile\PHPTelemetry\Contracts\TimeProviderInterface;
+use NodePile\PHPTelemetry\Support\TimeProvider;
 use NodePile\PHPTelemetry\Enums\Level;
 use NodePile\PHPTelemetry\Logger;
 
 class LoggerTest extends TestCase
 {
-	private Logger $logger;
+	private LoggerInterface $logger;
 
 	protected function setUp(): void
 	{
 		parent::setUp();
 
-		$this->logger = new Logger();
+		$driverManagerMock = $this->createMock(DriverManagerInterface::class);
+		$timeProvider = new TimeProvider();
+
+		$this->logger = new Logger($driverManagerMock, $timeProvider);
 	}
 
 	/**
@@ -25,9 +32,8 @@ class LoggerTest extends TestCase
 	public function testSupportedLevelsLoader()
 	{
 		$knownLevels = array_map(fn(Level $level) => $level->value, Level::cases());
-		$loadedLevels = $this->logger->getSupportedLevels();
 
-		$this->assertEqualsCanonicalizing($knownLevels, $loadedLevels);
+		$this->assertEqualsCanonicalizing($knownLevels, $this->logger->getSupportedLevels());
 	}
 
 	/**
@@ -63,7 +69,7 @@ class LoggerTest extends TestCase
 	}
 
 	/**
-	 * Test that log with unsupported level thros an InvalidLevelException
+	 * Test that log with unsupported level throws an InvalidLevelException
 	 */
 	public function testLogThrowsExceptionForUnsupportedLevel()
 	{


### PR DESCRIPTION
Add DI to Logger (DriverManagerInterface and TimeProviderInterface).

Update LoggerTest
- Good to keep in mind that the current implementation requires a \DateTimeInterface for the Entry model $timestamp which can't be mocked so tests have to rely on actual concrete implementation of ...\Support\TimeProvider