### PR TITLE
Fix type in TransactionLogger level case

### DIFF
--- a/src/TransactionLogger.php
+++ b/src/TransactionLogger.php
@@ -73,7 +73,7 @@ class TransactionLogger implements TransactionLoggerInterface
 	 */
 	public function info(string $message, array $context = []): void 
 	{
-		$this->log(Level::info->value, $message, $context);
+		$this->log(Level::Info->value, $message, $context);
 	}
 
 	/**


### PR DESCRIPTION
Fix the 'info' (should be 'Info' - capital 'I') for the Level case. 